### PR TITLE
change tunnel key to prn, add interface as value

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,3 +17,22 @@ Peridio RAT is designed to operate on Linux based systems and requires the follo
 * Linux Kernel with Wireguard enabled.
 * `wireguard-tools`: Tools for wg-quick.
 * `ss`: For scanning local ports
+
+## Looking up a tunnel server via interface id
+
+You can use `Registry.select` to look up `Peridio.RAT.Tunnel` servers by interface using a match spec. Match spec's are so easy!
+
+```elixir
+Registry.select(:tunnels, [{{:"$1", :"$2", :"$3"}, [{:==, {:map_get, :id, :"$3"}, "peridio-RSLO2KQ"}], [{{:"$1", :"$2", :"$3"}}]}])
+[
+  {"5167cecf-64e6-4eef-b694-5b8f490dc429",
+   #PID<0.1319.0>,
+   %Peridio.RAT.WireGuard.Interface{
+     id: "peridio-RSLO2KQ",
+     ip_address: %Peridio.RAT.Network.IP{address: 3232235544},
+     port: 49677,
+     private_key: "...",
+     public_key: "..."
+   }}
+]
+```

--- a/lib/peridio/rat.ex
+++ b/lib/peridio/rat.ex
@@ -3,8 +3,9 @@ defmodule Peridio.RAT do
 
   # What is needed to open a tunnel?
   # We need the peer and interface information structs
-  def open_tunnel(interface, peer, opts \\ []) do
+  def open_tunnel(id, interface, peer, opts \\ []) do
     state = %Tunnel.State{
+      id: id,
       interface: interface,
       peer: peer,
       expires_at: opts[:expires_at],
@@ -23,6 +24,7 @@ defmodule Peridio.RAT do
     end
   end
 
+  @spec close_tunnel(any()) :: :ok | {:error, :not_running}
   def close_tunnel(id) do
     case GenServer.whereis(Tunnel.generate_via_tuple(id)) do
       nil ->

--- a/lib/peridio/rat/tunnel.ex
+++ b/lib/peridio/rat/tunnel.ex
@@ -65,7 +65,8 @@ defmodule Peridio.RAT.Tunnel do
   @connection_timeout 60 * 5
 
   defmodule State do
-    defstruct interface: nil,
+    defstruct id: nil,
+              interface: nil,
               peer: nil,
               expires_at: nil,
               opts: []
@@ -73,6 +74,7 @@ defmodule Peridio.RAT.Tunnel do
 
   # Public Functions
   def generate_via_tuple(id), do: {:via, Registry, {:tunnels, id}}
+  def generate_via_tuple(id, interface), do: {:via, Registry, {:tunnels, id, interface}}
 
   def child_spec(args) do
     %{
@@ -83,7 +85,7 @@ defmodule Peridio.RAT.Tunnel do
   end
 
   def start_link(%State{} = state) do
-    GenServer.start_link(__MODULE__, state, name: generate_via_tuple(state.interface.id))
+    GenServer.start_link(__MODULE__, state, name: generate_via_tuple(state.id, state.interface))
   end
 
   # Server Process Callbacks


### PR DESCRIPTION
This PR will let us track tunnels by PRN and also look them up by interface name if necessary using `Registry.select`. It removes the need to tract the relationship in an Agent. 