### PR TITLE
Added list and get_by_interface_id for tunnels

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -21,7 +21,7 @@ jobs:
     - name: Set up Elixir
       uses: erlef/setup-beam@v1
       with:
-        elixir-version: '1.17.0'
+        elixir-version: '1.17.2'
         otp-version: '27.0'
     - name: Restore dependencies cache
       uses: actions/cache@v4


### PR DESCRIPTION
Added helper functions for 
* `list_tunnels` returning a list of 3 tuples `{pid, tunnel_id, interface}`
* `get_tunnel_by_interface_id` returning 3 tuple `{pid, tunnel_id, interface}` | `nil`