### PR TITLE
Tunnel Resumption Feature

### DIFF
--- a/lib/peridio/rat/network.ex
+++ b/lib/peridio/rat/network.ex
@@ -34,7 +34,7 @@ defmodule Peridio.RAT.Network do
         CIDR.difference(reservation, cidr) |> List.flatten()
       end)
 
-    List.flatten(available ++ available_from_reserved)
+    List.flatten(available ++ available_from_reserved) |> Enum.uniq()
   end
 
   def available_ports(port_range \\ @default_ports) do
@@ -54,7 +54,7 @@ defmodule Peridio.RAT.Network do
             end
           end)
 
-        resp
+        Enum.uniq(resp)
 
       _error ->
         :error

--- a/lib/peridio/rat/network/ip.ex
+++ b/lib/peridio/rat/network/ip.ex
@@ -20,6 +20,14 @@ defmodule Peridio.RAT.Network.IP do
     }
   end
 
+  def new(ipv4_string) when is_binary(ipv4_string) do
+    ipv4_string
+    |> String.split(".")
+    |> Enum.map(&String.to_integer/1)
+    |> List.to_tuple()
+    |> new()
+  end
+
   def tuple_to_integer({a, b, c, d}) do
     <<ipv4_int::unsigned-integer-size(32)>> = <<a, b, c, d>>
     ipv4_int

--- a/lib/peridio/rat/utils.ex
+++ b/lib/peridio/rat/utils.ex
@@ -4,4 +4,144 @@ defmodule Peridio.RAT.Utils do
     |> :crypto.strong_rand_bytes()
     |> Base.encode32(padding: false)
   end
+
+  @doc """
+  Returns the differences between two maps as a map containing only the
+  different or new values. The resulting map maintains the same structure
+  as the input maps, but only includes paths where values differ.
+
+  For nested maps, it recursively compares and returns only the different branches.
+  For scalar values, it returns the value from the second map when different.
+
+  ## Examples:
+      iex> Peridio.RAT.Utils.diff(
+      ...>   %{a: 1, b: %{c: 2, d: 3}, e: 5},
+      ...>   %{a: 1, b: %{c: 4, d: 3}, e: 6}
+      ...> )
+      %{b: %{c: 4}, e: 6}
+
+      iex> Peridio.RAT.Utils.diff(
+      ...>   %{nested: %{a: 1, b: 2}, same: 3},
+      ...>   %{nested: %{a: 1, b: 3}, same: 3}
+      ...> )
+      %{nested: %{b: 3}}
+  """
+  def diff(map1, map2) when is_map(map1) and is_map(map2) do
+    (Map.keys(map1) ++ Map.keys(map2))
+    |> Enum.uniq()
+    |> Enum.reduce(%{}, fn key, acc ->
+      value1 = Map.get(map1, key)
+      value2 = Map.get(map2, key)
+
+      case {value1, value2} do
+        {v1, v2} when is_map(v1) and is_map(v2) ->
+          case diff(v1, v2) do
+            diff_map when map_size(diff_map) == 0 -> acc
+            diff_map -> Map.put(acc, key, diff_map)
+          end
+
+        {nil, v2} when not is_nil(v2) ->
+          Map.put(acc, key, v2)
+
+        {v1, nil} when not is_nil(v1) ->
+          Map.put(acc, key, nil)
+
+        {v1, v2} when v1 != v2 ->
+          Map.put(acc, key, v2)
+
+        _ ->
+          acc
+      end
+    end)
+  end
+
+  def deep_merge(left, right) when is_map(left) and is_map(right) do
+    Map.merge(left, right, &deep_resolve/3)
+  end
+
+  @doc """
+  Takes a map and a list of keys, returns a list of key-value tuples sorted according
+  to the provided key order. Keys not in the sort list are appended at the end
+  in their original order.
+
+  ## Examples:
+      iex> MapSort.sort_by_keys(
+      ...>   %{"name" => "John", "age" => 30, "city" => "NY"},
+      ...>   ["age", "name", "country"]
+      ...> )
+      [{"age", 30}, {"name", "John"}, {"city", "NY"}]
+
+      # With atom keys
+      iex> MapSort.sort_by_keys(
+      ...>   %{name: "John", age: 30, city: "NY"},
+      ...>   ["age", "name"]
+      ...> )
+      [{:age, 30}, {:name, "John"}, {:city, "NY"}]
+  """
+  def sort_by_keys(map, sort_keys) when is_map(map) and is_list(sort_keys) do
+    # Convert sort_keys to strings for comparison
+    string_sort_keys = Enum.map(sort_keys, &to_string/1)
+
+    # Convert all map entries to list of tuples
+    map_entries = Map.to_list(map)
+
+    # Split entries into sorted and unsorted
+    {sorted_entries, remaining_entries} = split_entries(map_entries, string_sort_keys)
+
+    # Combine sorted entries with remaining entries
+    sorted_entries ++ remaining_entries
+  end
+
+  # Handle invalid inputs
+  def sort_by_keys(_, _), do: raise(ArgumentError, "Expected a map and a list of keys")
+
+  defp split_entries(entries, sort_keys) do
+    # Create sorting function based on position in sort_keys
+    sort_fn = fn {key, _} ->
+      key_str = to_string(key)
+
+      case Enum.find_index(sort_keys, &(&1 == key_str)) do
+        # Put at end if not in sort list
+        nil -> length(sort_keys)
+        idx -> idx
+      end
+    end
+
+    # Split and sort entries that are in sort_keys
+    {sorted, remaining} =
+      Enum.split_with(entries, fn {key, _} ->
+        key_str = to_string(key)
+        Enum.member?(sort_keys, key_str)
+      end)
+
+    {Enum.sort_by(sorted, sort_fn), remaining}
+  end
+
+  @doc """
+  Same as sort_by_keys/2 but returns a map. Note that the order is only guaranteed
+  when using Erlang version 21 or later.
+
+  ## Examples:
+      iex> MapSort.sort_by_keys_to_map(
+      ...>   %{"name" => "John", "age" => 30, "city" => "NY"},
+      ...>   ["age", "name", "country"]
+      ...> )
+      %{"age" => 30, "name" => "John", "city" => "NY"}
+  """
+  def sort_by_keys_to_map(map, sort_keys) do
+    map
+    |> sort_by_keys(sort_keys)
+    |> Map.new()
+  end
+
+  # If it's not a map, we want the value from the right
+  defp deep_resolve(_key, left, right) when is_map(left) and is_map(right) do
+    deep_merge(left, right)
+  end
+
+  # If the right value is nil, keep the left value
+  defp deep_resolve(_key, _left, nil), do: nil
+
+  # Otherwise, prefer the right value
+  defp deep_resolve(_key, _left, right), do: right
 end

--- a/lib/peridio/rat/wireguard.ex
+++ b/lib/peridio/rat/wireguard.ex
@@ -22,6 +22,10 @@ defmodule Peridio.RAT.WireGuard do
     @client.teardown_interface(interface_name, opts)
   end
 
+  def list_interfaces(opts \\ []) do
+    @client.list_interfaces(opts)
+  end
+
   def generate_key_pair() do
     @client.generate_key_pair()
   end

--- a/lib/peridio/rat/wireguard/behaviour.ex
+++ b/lib/peridio/rat/wireguard/behaviour.ex
@@ -9,6 +9,7 @@ defmodule Peridio.RAT.WireGuard.WireGuardBehaviour do
   @callback bring_up_interface(String.t(), Keyword.t()) :: {String.t(), integer()}
   @callback teardown_interface(String.t(), Keyword.t()) :: {String.t(), integer()}
   @callback generate_key_pair() :: %{atom() => String.t(), atom() => String.t()}
+  @callback list_interfaces(Keyword.t()) :: [{Interface.t(), Peer.t()}]
 
   # Monitoring and Stats
   @callback rx_packet_stats(String.t()) :: {integer(), integer()}

--- a/lib/peridio/rat/wireguard/interface.ex
+++ b/lib/peridio/rat/wireguard/interface.ex
@@ -48,10 +48,9 @@ defmodule Peridio.RAT.WireGuard.Interface do
     }
   end
 
-  def used_interfaces() do
-    with {:ok, interfaces} <- :inet.getifaddrs() do
+  def network_interfaces() do
+    with {:ok, interfaces} <- :inet.getiflist() do
       interfaces
-      |> Enum.map(&elem(&1, 0))
       |> Enum.map(&to_string/1)
       |> Enum.filter(&String.starts_with?(&1, @ifprefix))
     end

--- a/lib/peridio/rat/wireguard/mock.ex
+++ b/lib/peridio/rat/wireguard/mock.ex
@@ -45,6 +45,11 @@ defmodule Peridio.RAT.WireGuard.Mock do
   end
 
   @impl WireGuardBehaviour
+  def list_interfaces(_opts) do
+    []
+  end
+
+  @impl WireGuardBehaviour
   def generate_key_pair() do
     %{
       public_key: "SfHcet4JVMU6QVhs9hVFiAWZOa8YcBpnSdEK1Nyy6nY=",

--- a/lib/peridio/rat/wireguard/quick_config.ex
+++ b/lib/peridio/rat/wireguard/quick_config.ex
@@ -1,0 +1,211 @@
+defmodule Peridio.RAT.WireGuard.QuickConfig do
+  alias Peridio.RAT.WireGuard.{Interface, Peer}
+  alias Peridio.RAT.Network.IP
+  alias Peridio.RAT.Utils
+
+  require Logger
+
+  defstruct interface: %{},
+            peer: %{},
+            extra: %{}
+
+  @conf_keys %{
+    "Interface" => [
+      "Address",
+      "DNS",
+      "MTU",
+      "Table",
+      "ListenPort",
+      "PrivateKey",
+      "PreUp",
+      "PreDown",
+      "PostUp",
+      "PostDown",
+      "SaveConfig"
+    ],
+    "Peer" => ["AllowedIPs", "PublicKey", "Endpoint", "PersistentKeepalive", "PresharedKey"]
+  }
+  @interface_keys ["ID", "Address", "ListenPort", "PrivateKey", "PublicKey"]
+  @peer_keys ["AllowedIPs", "PublicKey", "Endpoint", "PersistentKeepalive"]
+
+  def new(%Interface{} = interface, %Peer{} = peer, extra \\ %{}) do
+    %__MODULE__{
+      interface: interface,
+      peer: peer,
+      extra: extra
+    }
+  end
+
+  def write(filepath, %__MODULE__{} = config) do
+    content = encode(config)
+    File.write(filepath, content)
+  end
+
+  def read(filepath) do
+    case File.read(filepath) do
+      {:ok, conf} -> {:ok, decode_conf(conf)}
+      error -> error
+    end
+  end
+
+  def read!(filepath) do
+    {:ok, quick_config} = read(filepath)
+    quick_config
+  end
+
+  def conf_parse(content) when is_binary(content) do
+    content
+    |> String.split("\n")
+    |> Stream.map(&String.trim/1)
+    |> Stream.map(&String.replace_prefix(&1, "# ", ""))
+    |> Enum.reject(&(String.length(&1) == 0 || String.starts_with?(&1, ";")))
+    |> conf_parse_lines(%{}, nil)
+  end
+
+  defp conf_parse_lines([], acc, _current_section), do: acc
+
+  defp conf_parse_lines([line | rest], acc, current_section) do
+    cond do
+      # Section header
+      String.match?(line, ~r/^\[(.*)\]$/) ->
+        [_, section] = Regex.run(~r/^\[(.*)\]$/, line)
+        conf_parse_lines(rest, Map.put_new(acc, section, %{}), section)
+
+      # Key-value pair
+      String.match?(line, ~r/^(.+?)=(.*)$/) ->
+        [_, key, value] = Regex.run(~r/^(.+?)=(.*)$/, line)
+        key = String.trim(key)
+        value = String.trim(value)
+
+        new_acc =
+          if current_section do
+            Map.update!(acc, current_section, fn section ->
+              Map.put(section, key, value)
+            end)
+          else
+            Map.put(acc, key, value)
+          end
+
+        conf_parse_lines(rest, new_acc, current_section)
+
+      true ->
+        conf_parse_lines(rest, acc, current_section)
+    end
+  end
+
+  def conf_to_string(data) do
+    conf_sections = Map.keys(@conf_keys)
+
+    data
+    |> Enum.map(fn
+      {section, values} when is_map(values) ->
+        section_str =
+          if section in conf_sections do
+            "[#{section}]\n"
+          else
+            "# [#{section}]\n"
+          end
+
+        section_keys = @conf_keys[section] || []
+
+        values_str =
+          values
+          |> Enum.map(fn
+            {k, v} ->
+              case k in section_keys do
+                true -> "#{k} = #{v}"
+                false -> "# #{k} = #{v}"
+              end
+          end)
+          |> Enum.join("\n")
+
+        section_str <> values_str
+
+      {key, value} ->
+        "# #{key} = #{value}"
+    end)
+    |> Enum.join("\n\n")
+  end
+
+  def encode(%Interface{} = interface) do
+    %{
+      "Address" => to_string(interface.ip_address),
+      "ListenPort" => to_string(interface.port),
+      "PrivateKey" => interface.private_key,
+      "ID" => interface.id,
+      "PublicKey" => interface.public_key
+    }
+  end
+
+  def encode(%Peer{} = peer) do
+    %{
+      "AllowedIPs" => "#{peer.ip_address}/32",
+      "PublicKey" => peer.public_key,
+      "Endpoint" => "#{peer.endpoint}:#{peer.port}",
+      "PersistentKeepalive" => to_string(peer.persistent_keepalive)
+    }
+  end
+
+  def encode(%__MODULE__{} = config) do
+    %{
+      "Interface" => encode(config.interface),
+      "Peer" => encode(config.peer)
+    }
+    |> Utils.deep_merge(config.extra)
+    |> Utils.sort_by_keys(["Interface", "Peer"])
+    |> conf_to_string()
+  end
+
+  def decode_conf(conf) do
+    conf = conf_parse(conf)
+    interface = decode_interface(conf["Interface"])
+    peer = decode_peer(conf["Peer"])
+    extra = decode_extra(conf)
+    %__MODULE__{interface: interface, peer: peer, extra: extra}
+  end
+
+  def decode_interface(interface_section) when is_map(interface_section) do
+    %Interface{
+      ip_address: IP.new(interface_section["Address"]),
+      port: String.to_integer(interface_section["ListenPort"]),
+      private_key: interface_section["PrivateKey"],
+      id: interface_section["ID"],
+      public_key: interface_section["PublicKey"]
+    }
+  end
+
+  def decode_peer(peer_section) when is_map(peer_section) do
+    [peer_endpoint, peer_port] = String.split(peer_section["Endpoint"], ":")
+    peer_port = String.to_integer(peer_port)
+    [peer_ip | _] = String.split(peer_section["AllowedIPs"], "/")
+
+    %Peer{
+      ip_address: peer_ip,
+      endpoint: peer_endpoint,
+      port: peer_port,
+      public_key: peer_section["PublicKey"],
+      persistent_keepalive: String.to_integer(peer_section["PersistentKeepalive"])
+    }
+  end
+
+  def decode_extra(conf) do
+    interface_extra = Map.drop(conf["Interface"], @interface_keys)
+    peer_extra = Map.drop(conf["Peer"], @peer_keys)
+
+    Map.drop(conf, ["Interface", "Peer"])
+    |> put_interface_extra(interface_extra)
+    |> put_peer_extra(peer_extra)
+  end
+
+  def put_interface_extra(extra, interface_extra) when map_size(interface_extra) == 0, do: extra
+
+  def put_interface_extra(extra, interface_extra) do
+    Map.put(extra, "Interface", interface_extra)
+  end
+
+  def put_peer_extra(extra, peer_extra) when map_size(peer_extra) == 0, do: extra
+
+  def put_peer_extra(extra, peer_extra) do
+    Map.put(extra, "Peer", peer_extra)
+  end
+end

--- a/priv/wg_conf_interface_template.eex
+++ b/priv/wg_conf_interface_template.eex
@@ -1,4 +1,0 @@
-[Interface]
-Address = <%= interface.ip_address %>
-ListenPort = <%= interface.port %>
-PrivateKey = <%= interface.private_key %>

--- a/priv/wg_conf_peer_template.eex
+++ b/priv/wg_conf_peer_template.eex
@@ -1,5 +1,0 @@
-[Peer]
-AllowedIPs = <%= peer.ip_address %>/32
-PublicKey = <%= peer.public_key %>
-<%= if peer.endpoint do %>Endpoint = <%= peer.endpoint %>:<%= peer.port %><% end %>
-<%= if peer.persistent_keepalive do %>PersistentKeepalive = <%= peer.persistent_keepalive %><% end %>

--- a/test/peridio/cidr_test.exs
+++ b/test/peridio/cidr_test.exs
@@ -1,6 +1,6 @@
 defmodule Peridio.CIDRTest do
   use ExUnit.Case
-  doctest Peridio.RAT
+  doctest Peridio.RAT.Network.CIDR
 
   alias Peridio.RAT.Network.CIDR
 

--- a/test/peridio/wireguard/quick_config_test.exs
+++ b/test/peridio/wireguard/quick_config_test.exs
@@ -1,0 +1,79 @@
+defmodule Peridio.UtilsTest do
+  use ExUnit.Case
+  doctest Peridio.RAT.WireGuard.QuickConfig
+
+  alias Peridio.RAT.WireGuard.{Interface, Peer, QuickConfig}
+  alias Peridio.RAT.Network.IP
+
+  @config """
+  [Interface]
+  Address = 10.0.0.1
+  ListenPort = 8080
+  PrivateKey = 2PSyTqm+3rXzUK+T8jBhgZp9UHjFkgVZv4bXncWMyXY=
+  # ID = peridio-56X4U4Q
+  # PublicKey = Pu7ymHtDqF4X9VNjVj9mYFBh/z7LGxY6VQJAGiSEgTM=
+
+  [Peer]
+  AllowedIPs = 10.0.0.3/32
+  PublicKey = h2W8fjxUwZH+G8/Qp/H7kzn4SQz/EJIhOVFMh6mmtX4=
+  Endpoint = 10.0.0.2:8081
+  PersistentKeepalive = 25
+
+  # [Peridio]
+  # TunnelID = prn:1:be4d30b4-de6b-47cd-85ea-a75e23fd63ef:tunnel:b3f1f699-3bc8-4c77-bda2-b974595d5e3f
+  """
+
+  describe "conf" do
+    test "parse" do
+      assert %{
+               "Interface" => %{
+                 "Address" => "10.0.0.1",
+                 "ListenPort" => "8080",
+                 "PrivateKey" => "2PSyTqm+3rXzUK+T8jBhgZp9UHjFkgVZv4bXncWMyXY=",
+                 "ID" => "peridio-56X4U4Q",
+                 "PublicKey" => "Pu7ymHtDqF4X9VNjVj9mYFBh/z7LGxY6VQJAGiSEgTM="
+               },
+               "Peer" => %{
+                 "AllowedIPs" => "10.0.0.3/32",
+                 "PublicKey" => "h2W8fjxUwZH+G8/Qp/H7kzn4SQz/EJIhOVFMh6mmtX4=",
+                 "Endpoint" => "10.0.0.2:8081",
+                 "PersistentKeepalive" => "25"
+               },
+               "Peridio" => %{
+                 "TunnelID" =>
+                   "prn:1:be4d30b4-de6b-47cd-85ea-a75e23fd63ef:tunnel:b3f1f699-3bc8-4c77-bda2-b974595d5e3f"
+               }
+             } = QuickConfig.conf_parse(@config)
+    end
+
+    test "read/write" do
+      interface =
+        %Interface{
+          id: "peridio-56X4U4Q",
+          ip_address: IP.new("10.0.0.1"),
+          port: 8080,
+          public_key: "Pu7ymHtDqF4X9VNjVj9mYFBh/z7LGxY6VQJAGiSEgTM=",
+          private_key: "2PSyTqm+3rXzUK+T8jBhgZp9UHjFkgVZv4bXncWMyXY="
+        }
+
+      peer =
+        %Peer{
+          ip_address: "10.0.0.3",
+          endpoint: "10.0.0.2",
+          port: 8081,
+          public_key: "h2W8fjxUwZH+G8/Qp/H7kzn4SQz/EJIhOVFMh6mmtX4=",
+          persistent_keepalive: 25
+        }
+
+      extra = %{
+        "Interface" => %{
+          "TunnelID" =>
+            "prn:1:be4d30b4-de6b-47cd-85ea-a75e23fd63ef:tunnel:b3f1f699-3bc8-4c77-bda2-b974595d5e3f"
+        }
+      }
+
+      config = QuickConfig.new(interface, peer, extra)
+      assert config == config |> QuickConfig.encode() |> QuickConfig.decode_conf()
+    end
+  end
+end


### PR DESCRIPTION
This PR does the following:

* wg-quick confs: Switch from eex templates to new QuickConfig module 
* Stuff additional interface and tunnel prn data into wg-quick configs to look up later
* Modify tunnel start logic to resume in different ways
  * If a config exists and the interface does not bring up the interface
  * if a config exists and the interface exists, resume.
  * If a config does not exist, configure the interface and then bring it up
* Add monitoring to ensure that the interface comes up on the system within 10 seconds, otherwise close.
* Add list_interfaces/1 to WireGuard behaviour. This will list the configs on disk and return QuickConfig structs.
* Add `on_exit` fun to Tunnel state. Called on terminate to allow application to specify clean up logic.
* Modify RAT.tunnel_close() to safely try to call GenServer stop. Prevents a race between terminate on_exit callback and server response. 
* Added tests for QuickConfig