### PR TITLE
Ensure quick config files are synced to disk

### DIFF
--- a/lib/peridio/rat/utils.ex
+++ b/lib/peridio/rat/utils.ex
@@ -4,4 +4,12 @@ defmodule Peridio.RAT.Utils do
     |> :crypto.strong_rand_bytes()
     |> Base.encode32(padding: false)
   end
+
+  def write_file_sync(filename, data) do
+    with {:ok, file} <- File.open(filename, [:write, :sync]),
+         :ok <- IO.binwrite(file, data),
+         :ok <- File.close(file) do
+      :ok
+    end
+  end
 end

--- a/lib/peridio/rat/wireguard/default.ex
+++ b/lib/peridio/rat/wireguard/default.ex
@@ -58,6 +58,7 @@ defmodule Peridio.RAT.WireGuard.Default do
     |> Stream.map(&Path.expand/1)
     |> Enum.map(&QuickConfig.read/1)
     |> Enum.filter(&match?({:ok, _}, &1))
+    |> Enum.map(&elem(&1, 1))
   end
 
   @impl WireGuardBehaviour

--- a/lib/peridio/rat/wireguard/quick_config.ex
+++ b/lib/peridio/rat/wireguard/quick_config.ex
@@ -1,6 +1,7 @@
 defmodule Peridio.RAT.WireGuard.QuickConfig do
   alias Peridio.RAT.WireGuard.{Interface, Peer}
   alias Peridio.RAT.Network.IP
+  alias Peridio.RAT.Utils
 
   require Logger
 
@@ -37,7 +38,7 @@ defmodule Peridio.RAT.WireGuard.QuickConfig do
 
   def write(filepath, %__MODULE__{} = config) do
     content = encode(config)
-    File.write(filepath, content)
+    Utils.write_file_sync(filepath, content)
   end
 
   def read(filepath) do


### PR DESCRIPTION
This also fixes up the default wireguard interface to unwrap `{:ok, result}` tuples