### PR TITLE
add try_get_state for tunnels

### DIFF
--- a/lib/peridio/rat.ex
+++ b/lib/peridio/rat.ex
@@ -53,7 +53,8 @@ defmodule Peridio.RAT do
     Peridio.RAT.DynamicSupervisor
     |> DynamicSupervisor.which_children()
     |> Enum.map(&elem(&1, 1))
-    |> Enum.map(&{&1, Tunnel.get_state(&1)})
+    |> Enum.map(&{&1, Tunnel.try_get_state(&1)})
+    |> Enum.reject(&is_nil/1)
     |> Enum.map(fn {pid, %Tunnel.State{id: id, interface: interface}} ->
       {id, pid, interface}
     end)

--- a/lib/peridio/rat/network.ex
+++ b/lib/peridio/rat/network.ex
@@ -65,7 +65,8 @@ defmodule Peridio.RAT.Network do
     Peridio.RAT.DynamicSupervisor
     |> DynamicSupervisor.which_children()
     |> Enum.map(&elem(&1, 1))
-    |> Enum.map(&Tunnel.get_state/1)
+    |> Enum.map(&Tunnel.try_get_state/1)
+    |> Enum.reject(&is_nil/1)
     |> Enum.map(& &1.interface.ip_address.address)
     |> Enum.map(&CIDR.from_ip_range(&1..&1))
     |> List.flatten()

--- a/lib/peridio/rat/tunnel.ex
+++ b/lib/peridio/rat/tunnel.ex
@@ -90,8 +90,13 @@ defmodule Peridio.RAT.Tunnel do
     }
   end
 
-  def get_state(pid) do
-    GenServer.call(pid, :get_state)
+  def try_get_state(pid) do
+    try do
+      GenServer.call(pid, :get_state)
+    catch
+      :exit, _ ->
+        nil
+    end
   end
 
   def extend(pid, expires_at) do


### PR DESCRIPTION
Fix issue where a tunnel process might be in the process of terminating when a caller is attempting to get its state for CIDR negotiation.